### PR TITLE
Exoplayer to media3 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     fragment_version = "1.6.1"
     constraintlayout_version = "2.1.4"
     viewpager2_version = "1.0.0"
-    exoplayer_version = "2.18.7"
+    media3 = "1.1.1"
     youtubeplayer_version = "11.1.0"
 
     firebase_version = "32.1.0"

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     implementation project(path: ':discussion')
     implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:$youtubeplayer_version"
     implementation "androidx.media3:media3-exoplayer:$media3"
-    implementation "androidx.media3:media3-exoplayer-dash:$media3"
     implementation "androidx.media3:media3-ui:$media3"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -61,7 +61,9 @@ dependencies {
     implementation project(path: ':core')
     implementation project(path: ':discussion')
     implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:$youtubeplayer_version"
-    implementation "com.google.android.exoplayer:exoplayer:$exoplayer_version"
+    implementation "androidx.media3:media3-exoplayer:$media3"
+    implementation "androidx.media3:media3-exoplayer-dash:$media3"
+    implementation "androidx.media3:media3-ui:$media3"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoFullScreenFragment.kt
@@ -8,17 +8,17 @@ import android.widget.FrameLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
-import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 import org.openedx.core.extension.requestApplyInsetsWhenAttached
 import org.openedx.core.presentation.global.WindowSizeHolder
 import org.openedx.core.presentation.global.viewBinding
 import org.openedx.course.R
 import org.openedx.course.databinding.FragmentVideoFullScreenBinding
-import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.core.parameter.parametersOf
 
 class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
 
@@ -67,6 +67,7 @@ class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
         initPlayer()
     }
 
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     private fun initPlayer() {
         with(binding) {
             if (exoPlayer == null) {
@@ -77,7 +78,7 @@ class VideoFullScreenFragment : Fragment(R.layout.fragment_video_full_screen) {
             playerView.setShowNextButton(false)
             playerView.setShowPreviousButton(false)
             val mediaItem = MediaItem.fromUri(viewModel.videoUrl)
-            exoPlayer?.setMediaItem(mediaItem, viewModel.currentVideoTime.toLong())
+            exoPlayer?.setMediaItem(mediaItem, viewModel.currentVideoTime)
             exoPlayer?.prepare()
             exoPlayer?.playWhenReady = false
 

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -176,7 +176,7 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
 
         val windowMetrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(requireActivity())
         val currentBounds = windowMetrics.bounds
-        val width = currentBounds.width()- requireContext().dpToPixel(32)
+        val width = currentBounds.width() - requireContext().dpToPixel(32)
         val minHeight = requireContext().dpToPixel(194).roundToInt()
         val height = (width / 16f * 9f).roundToInt()
         val layoutParams = binding.playerView.layoutParams as FrameLayout.LayoutParams

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -18,9 +18,13 @@ import androidx.compose.ui.Modifier
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 import org.openedx.core.extension.computeWindowSizeClasses
 import org.openedx.core.extension.dpToPixel
 import org.openedx.core.extension.objectToString
@@ -38,9 +42,6 @@ import org.openedx.course.presentation.ui.ConnectionErrorView
 import org.openedx.course.presentation.ui.VideoRotateView
 import org.openedx.course.presentation.ui.VideoSubtitles
 import org.openedx.course.presentation.ui.VideoTitle
-import org.koin.android.ext.android.inject
-import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.core.parameter.parametersOf
 import kotlin.math.roundToInt
 
 class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
@@ -203,7 +204,8 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
         }
     }
 
-    private fun initPlayer() {
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    private fun  initPlayer() {
         with(binding) {
             if (exoPlayer == null) {
                 exoPlayer = ExoPlayer.Builder(requireContext())

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -1,6 +1,5 @@
 package org.openedx.course.presentation.unit.video
 
-import android.graphics.Point
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -21,7 +20,7 @@ import androidx.fragment.app.Fragment
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.PlayerView
+import androidx.window.layout.WindowMetricsCalculator
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -173,12 +172,11 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             }
         }
 
-        binding.connectionError.isVisible =
-            !viewModel.hasInternetConnection && !viewModel.isDownloaded
-        val display = requireActivity().windowManager.defaultDisplay
-        val size = Point()
-        display.getSize(size)
-        val width = size.x - requireContext().dpToPixel(32)
+        binding.connectionError.isVisible = !viewModel.hasInternetConnection && !viewModel.isDownloaded
+
+        val windowMetrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(requireActivity())
+        val currentBounds = windowMetrics.bounds
+        val width = currentBounds.width()- requireContext().dpToPixel(32)
         val minHeight = requireContext().dpToPixel(194).roundToInt()
         val height = (width / 16f * 9f).roundToInt()
         val layoutParams = binding.playerView.layoutParams as FrameLayout.LayoutParams

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
@@ -1,7 +1,7 @@
 package org.openedx.course.presentation.unit.video
 
 import androidx.lifecycle.viewModelScope
-import com.google.android.exoplayer2.C
+import androidx.media3.common.C
 import org.openedx.core.BaseViewModel
 import org.openedx.course.data.repository.CourseRepository
 import org.openedx.core.system.notifier.CourseNotifier

--- a/course/src/main/res/layout-w600dp-h480dp/fragment_video_unit.xml
+++ b/course/src/main/res/layout-w600dp-h480dp/fragment_video_unit.xml
@@ -34,7 +34,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cv_video_title">
 
-            <com.google.android.exoplayer2.ui.StyledPlayerView
+            <androidx.media3.ui.PlayerView
                 android:id="@+id/player_view"
                 android:layout_width="560dp"
                 android:layout_height="100dp"

--- a/course/src/main/res/layout/fragment_video_full_screen.xml
+++ b/course/src/main/res/layout/fragment_video_full_screen.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.exoplayer2.ui.StyledPlayerView
+    <androidx.media3.ui.PlayerView
         android:id="@+id/player_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/course/src/main/res/layout/fragment_video_unit.xml
+++ b/course/src/main/res/layout/fragment_video_unit.xml
@@ -27,7 +27,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/cv_video_title">
 
-        <com.google.android.exoplayer2.ui.StyledPlayerView
+        <androidx.media3.ui.PlayerView
             android:id="@+id/player_view"
             android:layout_width="match_parent"
             android:layout_height="100dp"


### PR DESCRIPTION
Migrated exoPlayer to media3. A minor change of deprecated logic.